### PR TITLE
Fix to purchase flow not handling user cancelation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ import inAppPurchase from "nativescript-iap";
 await inAppPurchase.restorePurchases();
 ```
 
+### (ANDROID ONLY) Consuming the purchased product
+```typescript
+import inAppPurchase from "nativescript-iap";
+
+inAppPurchase.consumePurchase(transaction) // transaction returned by the "purchaseUpdated" hook.
+    .then(() => {
+        // transaction product was consumed and can be bought again.
+    }).catch((e) => {
+        // Error
+        // e: { code: billingResult.getResponseCode(), error: billingResult.getDebugMessage() }
+        // See https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingResponseCode
+        // for meaning of returned ResponseCodes.
+    });
+```
+
 ### Showing the price consent dialog
 ```typescript
 import inAppPurchase from "nativescript-iap";

--- a/docs/Api.md
+++ b/docs/Api.md
@@ -9,6 +9,12 @@ Notifies the store that the app finished processing the transaction.
 
 All purchases require finish, regardless of whether it succeeded or failed Failure to complete a succeeded purchase will result in that purchase being refunded. 
 
+**(ANDROID ONLY) consumePurchase(transaction: `Transaction`)**: *Promise\<void\>*  
+Consumes the purchase represented by the given transaction.
+
+Resolves if `getResponseCode() === BillingResponseCode.OK`
+else it rejects with an Object: `{ code: Number, error: String }`.
+
 **getProducts(productsIds: string[])**: *Promise\<Product[]\>*  
 Retrieves localized information from the store about a specified list of products.
 

--- a/docs/Api.md
+++ b/docs/Api.md
@@ -9,8 +9,8 @@ Notifies the store that the app finished processing the transaction.
 
 All purchases require finish, regardless of whether it succeeded or failed Failure to complete a succeeded purchase will result in that purchase being refunded. 
 
-**(ANDROID ONLY) consumePurchase(transaction: `Transaction`)**: *Promise\<void\>*  
-Consumes the purchase represented by the given transaction.
+**consumePurchase(transaction: `Transaction`)**: *Promise\<void\>*  
+Android only: Consumes the purchase represented by the given transaction.
 
 Resolves if `getResponseCode() === BillingResponseCode.OK`
 else it rejects with an Object: `{ code: Number, error: String }`.

--- a/src/purchase/purchase.android.ts
+++ b/src/purchase/purchase.android.ts
@@ -26,37 +26,52 @@ export class InAppPurchase extends InAppPurchaseBase {
     //#region Native methods
 
     private async onPurchasesUpdated(billingResult: com.android.billingclient.api.BillingResult, purchases: java.util.List<com.android.billingclient.api.Purchase>) {
-        const nativeTransactions = purchases.toArray();
-        const transactions = new Array<Transaction>();
-
-        for (let i = 0; i < nativeTransactions.length; i++) {
-            const transaction = new Transaction(nativeTransactions[i]);
-            switch (billingResult.getResponseCode()) {
-                case com.android.billingclient.api.BillingClient.BillingResponseCode.USER_CANCELED:
-                    transaction.error = new PurchaseError(
-                        PurchaseErrorCode.canceled,
-                        billingResult.getDebugMessage() ?? "User canceled");
-                    break;
-                case com.android.billingclient.api.BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED:
-                    transaction.error = new PurchaseError(
-                        PurchaseErrorCode.itemAlreadyOwned,
-                        billingResult.getDebugMessage() ?? "Item already owned");
-                    break;
-                case com.android.billingclient.api.BillingClient.BillingResponseCode.ITEM_UNAVAILABLE:
-                    transaction.error = new PurchaseError(
-                        PurchaseErrorCode.itemUnavailable,
-                        billingResult.getDebugMessage() ?? "Item unavailable");
-                    break;
+        if (billingResult.getResponseCode() == com.android.billingclient.api.BillingClient.BillingResponseCode.OK && purchases != null) {
+            const nativeTransactions = purchases.toArray();
+            const transactions = new Array<Transaction>();
+    
+            for (let i = 0; i < nativeTransactions.length; i++) {
+                const transaction = new Transaction(nativeTransactions[i]);
+                switch (billingResult.getResponseCode()) {
+                    case com.android.billingclient.api.BillingClient.BillingResponseCode.USER_CANCELED:
+                        transaction.error = new PurchaseError(
+                            PurchaseErrorCode.canceled,
+                            billingResult.getDebugMessage() ?? "User canceled");
+                        break;
+                    case com.android.billingclient.api.BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED:
+                        transaction.error = new PurchaseError(
+                            PurchaseErrorCode.itemAlreadyOwned,
+                            billingResult.getDebugMessage() ?? "Item already owned");
+                        break;
+                    case com.android.billingclient.api.BillingClient.BillingResponseCode.ITEM_UNAVAILABLE:
+                        transaction.error = new PurchaseError(
+                            PurchaseErrorCode.itemUnavailable,
+                            billingResult.getDebugMessage() ?? "Item unavailable");
+                        break;
+                }
+    
+                transactions.push(transaction);
             }
+    
+            this.notify({
+                eventName: InAppPurchase.purchaseUpdatedEvent,
+                object: this,
+                transactions: transactions
+            } as PurchaseEventData);
 
-            transactions.push(transaction);
+        } else if (billingResult.getResponseCode() == com.android.billingclient.api.BillingClient.BillingResponseCode.USER_CANCELED) {
+            // Handle an error caused by a user cancelling the purchase flow.
+            this.notify({
+                eventName: InAppPurchase.purchaseUpdatedEvent,
+                object: this,
+                transactions: [{
+                    state: TransactionState.failed,
+                    error: new PurchaseError(PurchaseErrorCode.canceled, billingResult.getDebugMessage())
+                }]
+            });
+        } else {
+            // Handle any other error codes.
         }
-
-        this.notify({
-            eventName: InAppPurchase.purchaseUpdatedEvent,
-            object: this,
-            transactions: transactions
-        } as PurchaseEventData);
     }
 
     private async connectAsync() {

--- a/src/purchase/purchase.android.ts
+++ b/src/purchase/purchase.android.ts
@@ -161,6 +161,29 @@ export class InAppPurchase extends InAppPurchaseBase {
         });
     }
 
+    public consumePurchase(transaction: Transaction): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            const ConsumeParams = com.android.billingclient.api.ConsumeParams.newBuilder()
+                .setPurchaseToken(transaction.nativeObject.getPurchaseToken())
+                .build();
+                
+            this.nativeObject.consumeAsync(
+                ConsumeParams,
+                new com.android.billingclient.api.ConsumeResponseListener({
+                    onConsumeResponse(billingResult) {
+                        if (billingResult.getResponseCode() === com.android.billingclient.api.BillingClient.BillingResponseCode.OK) {
+                            resolve();
+                        } else {
+                            reject({ 
+                                code: billingResult.getResponseCode(),
+                                error: billingResult.getDebugMessage()
+                            });
+                        }
+                    }
+                }));
+        });
+    }
+
     public async getProducts(productsIds: string[]): Promise<Product[]> {
         await this.connectAsync();
 

--- a/src/purchase/purchase.android.ts
+++ b/src/purchase/purchase.android.ts
@@ -154,7 +154,10 @@ export class InAppPurchase extends InAppPurchaseBase {
                         if (billingResult.getResponseCode() === com.android.billingclient.api.BillingClient.BillingResponseCode.OK) {
                             resolve();
                         } else {
-                            reject(billingResult.getDebugMessage());
+                            reject({
+                                code: billingResult.getResponseCode(),
+                                error: billingResult.getDebugMessage()
+                            });
                         }
                     }
                 }));
@@ -163,12 +166,12 @@ export class InAppPurchase extends InAppPurchaseBase {
 
     public consumePurchase(transaction: Transaction): Promise<void> {
         return new Promise<void>((resolve, reject) => {
-            const ConsumeParams = com.android.billingclient.api.ConsumeParams.newBuilder()
+            const consumeParams = com.android.billingclient.api.ConsumeParams.newBuilder()
                 .setPurchaseToken(transaction.nativeObject.getPurchaseToken())
                 .build();
-                
+
             this.nativeObject.consumeAsync(
-                ConsumeParams,
+                consumeParams,
                 new com.android.billingclient.api.ConsumeResponseListener({
                     onConsumeResponse(billingResult) {
                         if (billingResult.getResponseCode() === com.android.billingclient.api.BillingClient.BillingResponseCode.OK) {
@@ -238,7 +241,7 @@ export class InAppPurchase extends InAppPurchaseBase {
     public async showPriceConsent(product?: Product): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             if (product == null) {
-                reject("Parameter \"product\" must not be null.");
+                reject("The parameter \"product\" must not be null.");
                 return;
             }
 

--- a/src/purchase/purchase.d.ts
+++ b/src/purchase/purchase.d.ts
@@ -10,6 +10,13 @@ export class InAppPurchase extends Observable {
     public nativeObject: any;
 
     /**
+     * Consumes a given in-app product. Consuming can only be done on an item that's owned,
+     * and as a result of consumption, the user will no longer own it.
+     * @param transaction The transaction to consume.
+     */
+    public consumePurchase(transaction: Transaction): Promise<void>;
+
+    /**
      * Notifies the store that the app finished processing the transaction.
      * @param transaction The transaction to finish.
      * 

--- a/src/purchase/purchase.ios.ts
+++ b/src/purchase/purchase.ios.ts
@@ -113,6 +113,11 @@ export class InAppPurchase extends InAppPurchaseBase {
         }
     }
 
+    /** Android only */
+    public consumePurchase(transaction: Transaction): Promise<void> {
+        return Promise.resolve();
+    }
+
     public finishTransaction(transaction: Transaction): Promise<void> {
         return new Promise((resolve, reject) => {
             if (transaction.state === TransactionState.restored) {


### PR DESCRIPTION
Added: Handling an error caused by a user cancelling the purchase flow.

Didn't change inner handling. 
Tried to replicate the response pattern of `this.notify({...});` for the USER_CANCELED case.
See https://developer.android.com/google/play/billing/integrate#launch (Example above figure 2)

This file still needs changes.
Fixes #9 